### PR TITLE
Fix typo: Replace 'match.pi' with 'math.pi'

### DIFF
--- a/liere_rotations.py
+++ b/liere_rotations.py
@@ -57,7 +57,7 @@ class LierePositionEncoder(PositionEncoderBase):
                 self.head_dim,
                 self.head_dim,
             ) *
-            match.pi * 2 # RoPE-Mixed scaled by 2 pi, scaling by a constant https://github.com/naver-ai/rope-vit/blob/c6aa201ee795daa4f841e2f9585164bb23a0b819/deit/models_v2_rope.py#L25
+            math.pi * 2 # RoPE-Mixed scaled by 2 pi, scaling by a constant https://github.com/naver-ai/rope-vit/blob/c6aa201ee795daa4f841e2f9585164bb23a0b819/deit/models_v2_rope.py#L25
         )
 
     def forward(self, image_sizes: torch.Tensor, dtype):


### PR DESCRIPTION
This PR fixes a typo in the generator parameter initialization.

Changes made:

- Replaced `match.pi` with `math.pi` 

Reason for change:
The original code used `match.pi`, which is not a valid Python expression. This has been corrected to `math.pi` to properly access pi from the math module.

This fix prevents potential runtime errors and ensures the correct initialization of generator_raw_params.